### PR TITLE
Implement MFE4 data type fix method.  

### DIFF
--- a/hapi-base/src/main/java/ca/uhn/hl7v2/parser/ParserConfiguration.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/parser/ParserConfiguration.java
@@ -41,6 +41,8 @@ public class ParserConfiguration {
     private Escaping escaping = new DefaultEscaping();
 	private boolean xmlDisableWhitespaceTrimmingOnAllNodes = false;
 	private Set<String> xmlDisableWhitespaceTrimmingOnNodeNames = Collections.emptySet();
+    private String myInvalidMfe5Type;
+    private String myDefaultMfe5Type;
 
 	/**
 	 * <p>
@@ -157,6 +159,18 @@ public class ParserConfiguration {
 		return myDefaultObx2Type;
 	}
 
+    /**
+     * Returns the default datatype ("ST", "NM", etc) for an MFE segment with a
+     * missing MFE-5 value
+     *
+     * @return Returns the default datatype ("ST", "NM", etc) for an OBX segment
+     *         with a missing MFE-5 value
+     * @see #setDefaultMfe5Type(String)
+     */
+    public String getDefaultMfe5Type() {
+        return myDefaultMfe5Type;
+    }
+
 	/**
 	 * @return Returns the forced encode strings added by
 	 *         {@link #addForcedEncode(String)}
@@ -186,6 +200,19 @@ public class ParserConfiguration {
 	public String getInvalidObx2Type() {
 		return myInvalidObx2Type;
 	}
+
+    /**
+     * Returns the value provides a default datatype ("ST", "NM", etc) for an
+     * MFE segment with an invalid MFE-5 value.
+     *
+     * @return Returns the value provides a default datatype ("ST", "NM", etc)
+     *         for an MFE segment with an invalid MFE-5 value.
+     * @see #setInvalidMfe5Type(String)
+     */
+    public String getInvalidMfe5Type() {
+        return myInvalidMfe5Type;
+    }
+
 
 	/**
 	 * Returns the behaviour to use when parsing a message and a nonstandard
@@ -346,6 +373,44 @@ public class ParserConfiguration {
 		myDefaultObx2Type = theDefaultObx2Type;
 	}
 
+    /**
+     * <p>
+     * If this property is set, the value provides a default datatype ("ST",
+     * "NM", etc) for an MFE segment with a missing MFE-5 value. This is useful
+     * when parsing messages from systems which do not correctly populate MFE-5.
+     * </p>
+     * <p>
+     * For example, if this property is set to "ST", and the following MFE
+     * segment is encountered:
+     *
+     * <pre>
+     * MFE||||This is a value
+     * </pre>
+     *
+     * It will be parsed as though it had read:
+     *
+     * <pre>
+     * MFE||||This is a value|ST
+     * </pre>
+     *
+     * </p>
+     * <p>
+     * Note that this configuration can also be set globally using the system
+     * property {@link FixFieldDataType#DEFAULT_MFE5_TYPE_PROP}, but any value provided to
+     * {@link ParserConfiguration} takes priority over the system property.
+     * </p>
+     *
+     * @param theDefaultMfe5Type
+     *            If this property is set, the value provides a default datatype
+     *            ("ST", "NM", etc) for an MFE segment with a missing MFE-5
+     *            value
+     * @see #setInvalidMfe5Type(String)
+     * @see FixFieldDataType#DEFAULT_MFE5_TYPE_PROP
+     */
+    public void setDefaultMfe5Type(String theDefaultMfe5Type) {
+        myDefaultMfe5Type = theDefaultMfe5Type;
+    }
+
 	/**
 	 * <p>
 	 * If set to <code>true</code> (default is <code>true</code>), when encoding
@@ -449,6 +514,45 @@ public class ParserConfiguration {
 	public void setInvalidObx2Type(String theInvalidObx2Type) {
 		myInvalidObx2Type = theInvalidObx2Type;
 	}
+
+    /**
+     * <p>
+     * If this property is set, the value provides a default datatype ("ST",
+     * "NM", etc) for an MFE segment with an invalid MFE-5 value. This is useful
+     * when parsing messages from systems which do not correctly populate MFE-5.
+     * </p>
+     * <p>
+     * For example, if this property is set to "ST", and the following MFE
+     * segment is encountered:
+     *
+     * <pre>
+     * MFE||||This is a value|INVALID
+     * </pre>
+     *
+     * It will be parsed as though it had read:
+     *
+     * <pre>
+     * MFE||||This is a value|ST
+     * </pre>
+     *
+     * </p>
+     * <p>
+     * Note that this configuration can also be set globally using the system
+     * property {@link FixFieldDataType#INVALID_MFE5_TYPE_PROP}, but any value provided to
+     * {@link ParserConfiguration} takes priority over the system property.
+     * </p>
+     *
+     * @param theInvalidMfe5Type
+     *            If this property is set, the value provides a default datatype
+     *            ("ST", "NM", etc) for an MFE segment with an invalid MFE-5
+     *            value. This is useful when parsing messages from systems which
+     *            do not correctly populate MFE-5.
+     * @see ParserConfiguration#setDefaultMfe5Type(String)
+     * @see FixFieldDataType#INVALID_MFE5_TYPE_PROP
+     */
+    public void setInvalidMfe5Type(String theInvalidMfe5Type) {
+        myInvalidMfe5Type = theInvalidMfe5Type;
+    }
 
 	/**
 	 * If set to <code>true</code> (default is <code>false</code>), pipe parser will be

--- a/hapi-test/src/test/java/ca/uhn/hl7v2/parser/ParserConfigurationTest.java
+++ b/hapi-test/src/test/java/ca/uhn/hl7v2/parser/ParserConfigurationTest.java
@@ -5,9 +5,11 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.model.v25.message.ORU_R01;
 
 public class ParserConfigurationTest  {
@@ -46,6 +48,101 @@ public class ParserConfigurationTest  {
         assertIllegalArgument(pc, "AAA-123-");
 
 	}
+
+
+    /**
+     * <p>
+     *     Test for {@link ParserConfiguration#setDefaultMfe5Type(String)}.  Attempt to parse a message with a missing MFE-5 value.
+     * </p>
+     * <p>
+     *     Setup: Set default MFE-5 type to 'ST' with {@link ParserConfiguration#setDefaultMfe5Type(String)}.  Attempt to parse sample message.
+     * </p>
+     * <p>
+     *     Expected Result:  Message will parse successfully
+     * </p>
+     */
+	@Test
+    public void test_setDefaultMfe5Type() throws Exception {
+
+        String message = "MSH|^~\\&|Send App|Send Fac|Rec App|Rec Fac|20070504141816||MFN^M02||P|2.6\r" +
+                         "MFE||||VALUE\r";
+
+        Parser p = new PipeParser();
+        p.getParserConfiguration().setDefaultMfe5Type("ST");
+
+        Message m = p.parse(message);
+
+        Assert.assertNotNull(m);
+    }
+
+    /**
+     * <p>
+     *     Test for {@link ParserConfiguration#setDefaultMfe5Type(String)}.  Attempt to parse a message with a missing MFE-5 value.
+     * </p>
+     * <p>
+     *     Setup: Attempt to parse sample message, not adjusting {@link ParserConfiguration}
+     * </p>
+     * <p>
+     *     Expected Result:  Message will fail to parse
+     * </p>
+     */
+    @Test(expected = HL7Exception.class)
+    public void test_setDefaultMfe5Type_systemDefault() throws Exception {
+
+        String message = "MSH|^~\\&|Send App|Send Fac|Rec App|Rec Fac|20070504141816||MFN^M02||P|2.6\r" +
+                         "MFE||||VALUE\r";
+
+        Parser p = new PipeParser();
+
+        p.parse(message);
+    }
+
+    /**
+     * <p>
+     *     Test for {@link ParserConfiguration#setInvalidMfe5Type(String)}.  Attempt to parse a message with an invalid MFE-5 value.
+     * </p>
+     * <p>
+     *     Setup: Set default MFE-5 type to 'ST' with {@link ParserConfiguration#setDefaultMfe5Type(String)}.  Attempt to parse sample message.
+     * </p>
+     * <p>
+     *     Expected Result:  Message will parse successfully
+     * </p>
+     */
+    @Test
+    public void test_setInvalidMfe5Type() throws Exception {
+
+        String message = "MSH|^~\\&|Send App|Send Fac|Rec App|Rec Fac|20070504141816||MFN^M02||P|2.6\r" +
+                         "MFE||||VALUE|INVALID\r";
+
+        Parser p = new PipeParser();
+        p.getParserConfiguration().setInvalidMfe5Type("ST");
+
+        Message m = p.parse(message);
+
+        Assert.assertNotNull(m);
+    }
+
+    /**
+     * <p>
+     *     Test for {@link ParserConfiguration#setInvalidMfe5Type(String)}.  Attempt to parse a message with an invalid MFE-5 value.
+     * </p>
+     * <p>
+     *     Setup: Attempt to parse sample message, not adjusting {@link ParserConfiguration}
+     * </p>
+     * <p>
+     *     Expected Result:  Message will fail to parse
+     * </p>
+     */
+    @Test(expected = HL7Exception.class)
+    public void test_setInvalidMfe5Type_systemDefault() throws Exception {
+
+        String message = "MSH|^~\\&|Send App|Send Fac|Rec App|Rec Fac|20070504141816||MFN^M02||P|2.6\r" +
+                         "MFE||||VALUE|INVALID\r";
+
+        Parser p = new PipeParser();
+
+        p.parse(message);
+    }
 	
 	private void assertIllegalArgument(ParserConfiguration pc, String forcedEncode) {
         try {


### PR DESCRIPTION
The `FixFieldDataType` class has a method to fix the datatype for the MFE-4 field for versions greater than V23.   This method did not have a full implementation, when compared to the method for OBX-5.  

Following the existing pattern used for OBX-5, this change completes the implementation for MFE-4. 

- Added options to `ParserConfiguration` to allow invalid/default datatype to be configured for MFE-5. Follows same convention as used for OBX-2 invalid/default configuration.
- Updates `FixFieldDataType` class to look for these `ParserConfiguration`  options, or optionally, system properties. 
- Added simple tests to validate the new functionality. 

