### PR TITLE
Fix issue where a `GenericMessage` cannot be encoded to XML.

### DIFF
--- a/hapi-base/src/main/java/ca/uhn/hl7v2/parser/DefaultXMLParser.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/parser/DefaultXMLParser.java
@@ -41,6 +41,7 @@ import org.w3c.dom.NodeList;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.HapiContext;
+import ca.uhn.hl7v2.model.GenericMessage;
 import ca.uhn.hl7v2.model.Group;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.model.Segment;
@@ -106,6 +107,12 @@ public class DefaultXMLParser extends XMLParser {
     public Document encodeDocument(Message source) throws HL7Exception {
         String messageClassName = source.getClass().getName();
         String messageName = messageClassName.substring(messageClassName.lastIndexOf('.') + 1);
+
+        // Handle GenericMessages which will have an errant $ in their class name.
+        if (source instanceof GenericMessage) {
+            messageName = messageName.replaceAll("\\$", "");
+        }
+
         try {
             Document doc = XMLUtils.emptyDocument(messageName);
             //Element root = doc.createElement(messageName);


### PR DESCRIPTION
Potential fix for issue where `GenericMessage` instances cannot be encoded to XML using the `DefaultXmlParser`.  closes: #20 

This may not be an ideal solution from a performance perspective, but it was a simple way to address the issue. 

We are currently using a custom `XmlParser` which implements this same change.  Having this within HAPI itself would certainly help streamline our code. 