### PR TITLE
Change to static logger

### DIFF
--- a/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractComposite.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractComposite.java
@@ -37,11 +37,10 @@ public abstract class AbstractComposite extends AbstractType implements
 
 	private static final long serialVersionUID = -2657103285266475699L;
 
-	protected Logger log;
+	private static final Logger log = LoggerFactory.getLogger(AbstractComposite.class);
 
 	public AbstractComposite(Message message) {
 		super(message);
-		log = LoggerFactory.getLogger(getClass());
 	}
 
 	@Override
@@ -57,7 +56,7 @@ public abstract class AbstractComposite extends AbstractType implements
 			@SuppressWarnings("unchecked") T ret = (T)getComponent(idx);
 			return ret;
 		} catch (HL7Exception e) {
-	         log.error("Unexpected problem accessing known data type component - this is a bug.", e);
+	         log.error("Unexpected problem accessing known data type component - this is a bug. Class is " + getClass().getName(), e);
 	         throw new RuntimeException(e);
 		}
 	}


### PR DESCRIPTION
The class ca.uhn.hl7v2.model.AbstractComposite creates a logger every time the constructor is called. 

1. Many types extend this class. Parsing a single message can create a large number of loggers.
2. The logger is only used one one error case which is unlikely.
3. Creating "instance" loggers is inconsistent with the usage of Logger throughout the rest of the project (normally they are static final).
4. Depending on the logging framework, Loggers can be slow to create. This can slow down message parsing.

On WildFly 17, changing the instance logger to a static one increased message parsing speed by 37x (on my local machine).
