### PR TITLE
Edited specs of HL7v2 over HTTP documentation

### DIFF
--- a/hapi-hl7overhttp/specification.html
+++ b/hapi-hl7overhttp/specification.html
@@ -343,7 +343,7 @@
 <li>
 							If the message is a &quot;vertical bar&quot; encoded HL7 v2.x message, the
 							content type SHALL be:<br />
-							<tt>&#160;&#160;&#160;&#160;x-application/hl7-v2+er7</tt>
+							<tt>&#160;&#160;&#160;&#160;x-application/hl7-v2</tt>
 						</li>
 						
 <li>
@@ -436,7 +436,7 @@
 					to indicate that a &quot;vertical bar&quot; encoded message is being transmitted.
 				</p>
 				
-<div class="source"><pre class="prettyprint">Content-Type: application/hl7-v2+er7; charset=utf-8</pre></div>
+<div class="source"><pre class="prettyprint">Content-Type: application/hl7-v2</pre></div>
 			
 			</div></div>
 			


### PR DESCRIPTION
Includes application/hl7-v2 to display correct header syntax when sending hl7v2 over http.