### PR TITLE
wait for socket close on simple server termination

### DIFF
--- a/hapi-base/src/main/java/ca/uhn/hl7v2/app/SimpleServer.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/app/SimpleServer.java
@@ -215,7 +215,10 @@ public class SimpleServer extends HL7Service {
 	@Override
 	protected void afterTermination() {
 		super.afterTermination();
-		acceptor.stop();
+		// use stopAndWait (instead of stop) to ensure port is released when this function returns,
+		// so that components using this server class can reuse the port without having to add
+		// logic to wait for port to be released
+		acceptor.stopAndWait();
 	}
 
 	/**

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -23,7 +23,6 @@
 			<action type="change" dev="James Agnew">
 				As of HAPI HL7v2 2.4, HAPI FHIR now requires JDK 11 or newer in order to build or use the library.
 			</action>
-
 			<action type="fix" dev="James Agnew">
 				The XML parser was vulnerable to XXE injections (meaning that the XML
 				parser could be coerced into inadvertently loading the contents of files

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -16,6 +16,11 @@
 			<action type="change" dev="James Agnew">
 				As of HAPI HL7v2 2.4, HAPI FHIR now requires JDK 11 or newer in order to build or use the library.
 			</action>
+			<action type="change" dev="Emre Dincturk">
+				SimpleServer now waits for its server socket to be closed when stopping. This makes it easier for
+				consumers of SimpleServer to reuse the port after stopping the server
+				without implementing a wait for the port to be released themselves.
+			</action>
 			<action type="fix" dev="James Agnew">
 				The XML parser was vulnerable to XXE injections (meaning that the XML
 				parser could be coerced into inadvertently loading the contents of files

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,13 @@
 		<title>HAPI</title>
 	</properties>
 	<body>
+		<release version="2.4.1" date="2023-11-01">
+			<action type="change" dev="Emre Dincturk">
+				SimpleServer now waits for its server socket to be closed when stopping. This makes it easier for
+				consumers of SimpleServer to reuse the port after stopping the server
+				without implementing a wait for the port to be released themselves.
+			</action>
+		</release>
 		<release version="2.5" date="2023-10-30">
 			<action type="change" dev="James Agnew">
 				HAPI HL7v2 2.5 is identical to HAPI FHIR 2.4, but uses the jakarta.servlet
@@ -16,11 +23,7 @@
 			<action type="change" dev="James Agnew">
 				As of HAPI HL7v2 2.4, HAPI FHIR now requires JDK 11 or newer in order to build or use the library.
 			</action>
-			<action type="change" dev="Emre Dincturk">
-				SimpleServer now waits for its server socket to be closed when stopping. This makes it easier for
-				consumers of SimpleServer to reuse the port after stopping the server
-				without implementing a wait for the port to be released themselves.
-			</action>
+
 			<action type="fix" dev="James Agnew">
 				The XML parser was vulnerable to XXE injections (meaning that the XML
 				parser could be coerced into inadvertently loading the contents of files

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -6,9 +6,9 @@
 	</properties>
 	<body>
 		<release version="2.4.1" date="2023-11-01">
-			<action type="change" dev="Emre Dincturk">
-				SimpleServer now waits for its server socket to be closed when stopping. This makes it easier for
-				consumers of SimpleServer to reuse the port after stopping the server
+			<action type="fix" dev="Emre Dincturk">
+				SimpleServer now waits for its server socket to be closed when stopAndWait is called.
+				This makes it easier for consumers of SimpleServer to reuse the port after stopping the server
 				without implementing a wait for the port to be released themselves.
 			</action>
 		</release>


### PR DESCRIPTION
makes the SimpleServer wait for socket to be closed on termination (when stopAndWait is called)  so that components using it don't have to wait themselves to re-use its port. 