### PR TITLE
Library and Version uplift(s)

### DIFF
--- a/hapi-hl7overhttp/pom.xml
+++ b/hapi-hl7overhttp/pom.xml
@@ -116,12 +116,12 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcmail-jdk16</artifactId>
+			<artifactId>bcmail-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 

--- a/hapi-hl7overhttp/signature.html
+++ b/hapi-hl7overhttp/signature.html
@@ -126,12 +126,12 @@
 		        
 <div class="source"><pre class="prettyprint">&lt;dependency&gt;
   &lt;groupId&gt;org.bouncycastle&lt;/groupId&gt;
-  &lt;artifactId&gt;bcprov-jdk16&lt;/artifactId&gt;
+  &lt;artifactId&gt;bcprov-jdk18on&lt;/artifactId&gt;
   &lt;version&gt;${bouncycastle.version}&lt;/version&gt;
 &lt;/dependency&gt;
 &lt;dependency&gt;
   &lt;groupId&gt;org.bouncycastle&lt;/groupId&gt;
-  &lt;artifactId&gt;bcmail-jdk16&lt;/artifactId&gt;
+  &lt;artifactId&gt;bcmail-jdk18on&lt;/artifactId&gt;
   &lt;version&gt;${bouncycastle.version}&lt;/version&gt;
 &lt;/dependency&gt;</pre></div>
 		        

--- a/hapi-hl7overhttp/src/site/xdoc/signature.xml.vm
+++ b/hapi-hl7overhttp/src/site/xdoc/signature.xml.vm
@@ -40,12 +40,12 @@
 		        </p>
 		        <source><![CDATA[<dependency>
   <groupId>org.bouncycastle</groupId>
-  <artifactId>bcprov-jdk16</artifactId>
+  <artifactId>bcprov-jdk18on</artifactId>
   <version>${bouncycastle.version}</version>
 </dependency>
 <dependency>
   <groupId>org.bouncycastle</groupId>
-  <artifactId>bcmail-jdk16</artifactId>
+  <artifactId>bcmail-jdk18on</artifactId>
   <version>${bouncycastle.version}</version>
 </dependency>]]></source>
 		        

--- a/hapi-testpanel/pom.xml
+++ b/hapi-testpanel/pom.xml
@@ -175,12 +175,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcmail-jdk16</artifactId>
+			<artifactId>bcmail-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -681,17 +681,17 @@
 		<hapi.version.testpanel>${project.version}</hapi.version.testpanel>
 
 		<!-- Dependency versions -->
-		<bouncycastle.version>1.46</bouncycastle.version>
+		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<commons-cli.version>1.2</commons-cli.version>
         <commons-lang.version>2.6</commons-lang.version>
 		<geronimo.jms.spec.version>1.1.1</geronimo.jms.spec.version>
         <hamcrest.version>2.2</hamcrest.version>
 		<mockito_version>4.8.1</mockito_version>
 		<jetty_version>12.0.2</jetty_version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13.2</junit.version>
 		<log4j.version>1.2.17</log4j.version> <!-- !! -->
 		<slf4j.version>1.7.30</slf4j.version>
-		<spring.version>5.2.6.RELEASE</spring.version>
+		<spring.version>5.3.34</spring.version>
 
 		<!-- Renamed properties for use in *.vm site documentation -->
 		<log4j_version>${log4j.version}</log4j_version>


### PR DESCRIPTION
Change from
  bcprov-jdk16 to bcprov-jdk18on
  bcmail-jdk16 to bcmail-jdk18on

Version changes:
    bouncycastle.version from '1.46' to '1.78.1'
    spring.version from '5.2.6.RELEASE' to '5.3.34'
    junit.version from '4.12' to '4.13.2'

Primary motivation:

Security vulnerabilities with

https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk16/1.46

and

https://mvnrepository.com/artifact/org.springframework/spring-context/5.2.6.RELEASE