### PR TITLE
Library and Version uplift(s) (bouncycastle, spring, junit) and (slf4j, log4j)

### DIFF
--- a/hapi-base/pom.xml
+++ b/hapi-base/pom.xml
@@ -18,13 +18,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${slf4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 			<optional>true</optional>
 		</dependency>

--- a/hapi-dist/pom.xml
+++ b/hapi-dist/pom.xml
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${slf4j.version}</version>
 			<optional>true</optional>
 		</dependency>
@@ -106,8 +106,8 @@
             <version>${hapi.version.structures}</version>
         </dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 			<optional>true</optional>
 		</dependency>

--- a/hapi-hl7overhttp/pom.xml
+++ b/hapi-hl7overhttp/pom.xml
@@ -60,13 +60,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${slf4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 			<optional>true</optional>
 		</dependency>

--- a/hapi-hl7overhttp/pom.xml
+++ b/hapi-hl7overhttp/pom.xml
@@ -116,12 +116,12 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcmail-jdk16</artifactId>
+			<artifactId>bcmail-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 

--- a/hapi-hl7overhttp/signature.html
+++ b/hapi-hl7overhttp/signature.html
@@ -126,12 +126,12 @@
 		        
 <div class="source"><pre class="prettyprint">&lt;dependency&gt;
   &lt;groupId&gt;org.bouncycastle&lt;/groupId&gt;
-  &lt;artifactId&gt;bcprov-jdk16&lt;/artifactId&gt;
+  &lt;artifactId&gt;bcprov-jdk18on&lt;/artifactId&gt;
   &lt;version&gt;${bouncycastle.version}&lt;/version&gt;
 &lt;/dependency&gt;
 &lt;dependency&gt;
   &lt;groupId&gt;org.bouncycastle&lt;/groupId&gt;
-  &lt;artifactId&gt;bcmail-jdk16&lt;/artifactId&gt;
+  &lt;artifactId&gt;bcmail-jdk18on&lt;/artifactId&gt;
   &lt;version&gt;${bouncycastle.version}&lt;/version&gt;
 &lt;/dependency&gt;</pre></div>
 		        

--- a/hapi-hl7overhttp/src/site/xdoc/signature.xml.vm
+++ b/hapi-hl7overhttp/src/site/xdoc/signature.xml.vm
@@ -40,12 +40,12 @@
 		        </p>
 		        <source><![CDATA[<dependency>
   <groupId>org.bouncycastle</groupId>
-  <artifactId>bcprov-jdk16</artifactId>
+  <artifactId>bcprov-jdk18on</artifactId>
   <version>${bouncycastle.version}</version>
 </dependency>
 <dependency>
   <groupId>org.bouncycastle</groupId>
-  <artifactId>bcmail-jdk16</artifactId>
+  <artifactId>bcmail-jdk18on</artifactId>
   <version>${bouncycastle.version}</version>
 </dependency>]]></source>
 		        

--- a/hapi-test/pom.xml
+++ b/hapi-test/pom.xml
@@ -218,13 +218,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${slf4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 			<optional>true</optional>
 		</dependency>

--- a/hapi-testpanel/pom.xml
+++ b/hapi-testpanel/pom.xml
@@ -175,12 +175,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcmail-jdk16</artifactId>
+			<artifactId>bcmail-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
 		<dependency>

--- a/hapi-testpanel/pom.xml
+++ b/hapi-testpanel/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.9</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/hapi-testpanel/pom.xml
+++ b/hapi-testpanel/pom.xml
@@ -157,14 +157,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${slf4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -689,8 +689,8 @@
 		<mockito_version>4.8.1</mockito_version>
 		<jetty_version>12.0.2</jetty_version>
 		<junit.version>4.13.2</junit.version>
-		<log4j.version>1.2.17</log4j.version> <!-- !! -->
-		<slf4j.version>1.7.30</slf4j.version>
+		<log4j.version>2.23.1</log4j.version> <!-- !! -->
+		<slf4j.version>1.7.36</slf4j.version>
 		<spring.version>5.3.34</spring.version>
 
 		<!-- Renamed properties for use in *.vm site documentation -->

--- a/pom.xml
+++ b/pom.xml
@@ -681,17 +681,17 @@
 		<hapi.version.testpanel>${project.version}</hapi.version.testpanel>
 
 		<!-- Dependency versions -->
-		<bouncycastle.version>1.46</bouncycastle.version>
+		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<commons-cli.version>1.2</commons-cli.version>
         <commons-lang.version>2.6</commons-lang.version>
 		<geronimo.jms.spec.version>1.1.1</geronimo.jms.spec.version>
         <hamcrest.version>2.2</hamcrest.version>
 		<mockito_version>4.8.1</mockito_version>
 		<jetty_version>12.0.2</jetty_version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13.2</junit.version>
 		<log4j.version>1.2.17</log4j.version> <!-- !! -->
 		<slf4j.version>1.7.30</slf4j.version>
-		<spring.version>5.2.6.RELEASE</spring.version>
+		<spring.version>5.3.34</spring.version>
 
 		<!-- Renamed properties for use in *.vm site documentation -->
 		<log4j_version>${log4j.version}</log4j_version>


### PR DESCRIPTION
This what is in https://github.com/hapifhir/hapi-hl7v2/pull/120 plus log4j and slf4j.

Library and Version uplift(s)

Change from 
  bcprov-jdk16 to bcprov-jdk18on
  bcmail-jdk16 to bcmail-jdk18on
  
  slf4j-log4j12 to slf4j-reload4j
  log4j to log4j-core
  
Version changes:
    bouncycastle.version from '1.46' to '1.78.1'
    spring.version from '5.2.6.RELEASE' to '5.3.34'
    junit.version from '4.12' to '4.13.2'
    
    log4j.version from '1.2.17' to '2.23.1'
    slf4j.version from '1.7.30' to '1.7.36'
    
Primary motivation:

Security vulnerabilities with 

https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk16/1.46

and

https://mvnrepository.com/artifact/org.springframework/spring-context/5.2.6.RELEASE

and

https://mvnrepository.com/artifact/log4j/log4j/1.2.16