### PR TITLE
Fix to AbstractMessage.copy() method

### DIFF
--- a/hapi-base/pom.xml
+++ b/hapi-base/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-base/pom.xml
+++ b/hapi-base/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>joda-time</artifactId>
             <version>2.1</version>
         </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
+		</dependency>
 	</dependencies>
 	<reporting>
 		<plugins>

--- a/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractMessage.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractMessage.java
@@ -44,7 +44,6 @@ import ca.uhn.hl7v2.validation.ValidationContext;
 import org.apache.commons.lang3.SerializationUtils;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Map;
@@ -433,61 +432,5 @@ public abstract class AbstractMessage extends AbstractGroup implements Message {
      */
     public AbstractMessage copy() throws HL7Exception{
         return SerializationUtils.clone(this);
-    }
-
-    private void copyParserRequiredMshFields(AbstractMessage theSource, AbstractMessage theTarget) throws HL7Exception {
-        String mshField = "MSH";
-        AbstractSegment sourceMsh = (AbstractSegment) theSource.get(mshField);
-        AbstractSegment targetMsh = (AbstractSegment) theTarget.get(mshField);
-
-        String msh1 = Terser.get(sourceMsh, 1, 0, 1, 1);
-        Terser.set(targetMsh, 1, 0, 1, 1, msh1);
-
-        String msh2 = Terser.get(sourceMsh, 2, 0, 1, 1);
-        Terser.set(targetMsh, 2, 0, 1, 1, msh2);
-    }
-
-    private void copyGroup(AbstractGroup theSource, AbstractGroup theTarget) throws HL7Exception {
-        String[] sourceNames = theSource.getNames();
-
-        for (String sourceName : sourceNames) {
-
-            Structure[] sourceStructures = theSource.getAll(sourceName);
-            for (int i = 0; i < sourceStructures.length; i++) {
-
-                Structure sourceStructure = sourceStructures[i];
-
-                if (sourceStructure instanceof AbstractGroup) {
-                    Structure targetGroup = theTarget.get(sourceName, i);
-                    copyGroup((AbstractGroup)sourceStructure, (AbstractGroup)targetGroup);
-
-                } else if (sourceStructure instanceof AbstractSegment) {
-
-                    boolean isNonStandardSegment = theSource.getNonStandardNames().contains(sourceName);
-                    if (isNonStandardSegment) {
-                        insertNonStandardSegment(theSource, theTarget, sourceName);
-                    }
-
-                    AbstractSegment sourceSegment = (AbstractSegment) sourceStructure;
-                    AbstractSegment targetSegment = (AbstractSegment) theTarget.get(sourceName, i);
-                    String segmentContents = sourceSegment.encode();
-                    targetSegment.parse(segmentContents);
-                }
-            }
-        }
-    }
-
-    private void insertNonStandardSegment(AbstractGroup theSource, AbstractGroup theTarget, String theNonStandardSegmentName) throws HL7Exception {
-        String[] sourceNames = theSource.getNames();
-        int sourceIndex = Arrays.asList(sourceNames).indexOf(theNonStandardSegmentName);
-
-        String[] targetNames = theTarget.getNames();
-        boolean shouldInsertAtEnd = sourceIndex >= targetNames.length;
-
-        if (shouldInsertAtEnd) {
-            theTarget.addNonstandardSegment(theNonStandardSegmentName);
-        } else {
-            theTarget.addNonstandardSegment(theNonStandardSegmentName, sourceIndex);
-        }
     }
 }

--- a/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractMessage.java
+++ b/hapi-base/src/main/java/ca/uhn/hl7v2/model/AbstractMessage.java
@@ -27,14 +27,6 @@ this file under either the MPL or the GPL.
 
 package ca.uhn.hl7v2.model;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import ca.uhn.hl7v2.AcknowledgmentCode;
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.Location;
@@ -49,6 +41,15 @@ import ca.uhn.hl7v2.util.ReflectionUtil;
 import ca.uhn.hl7v2.util.StringUtil;
 import ca.uhn.hl7v2.util.Terser;
 import ca.uhn.hl7v2.validation.ValidationContext;
+import org.apache.commons.lang3.SerializationUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A default implementation of Message. 
@@ -431,12 +432,7 @@ public abstract class AbstractMessage extends AbstractGroup implements Message {
      * @throws HL7Exception If an error occurs while the message is being copied
      */
     public AbstractMessage copy() throws HL7Exception{
-        AbstractMessage clonedMessage = ReflectionUtil.instantiateMessage(this.getClass(), this.getModelClassFactory());
-        clonedMessage.setParser(this.getParser());
-
-        copyParserRequiredMshFields(this, clonedMessage);
-        copyGroup(this, clonedMessage);
-        return clonedMessage;
+        return SerializationUtils.clone(this);
     }
 
     private void copyParserRequiredMshFields(AbstractMessage theSource, AbstractMessage theTarget) throws HL7Exception {

--- a/hapi-bom/pom.xml
+++ b/hapi-bom/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>hapi</artifactId>
         <groupId>ca.uhn.hapi</groupId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
    </parent>
     
     <dependencyManagement>

--- a/hapi-dist/pom.xml
+++ b/hapi-dist/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-examples/pom.xml
+++ b/hapi-examples/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-hl7overhttp/pom.xml
+++ b/hapi-hl7overhttp/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/hapi-osgi-base/pom.xml
+++ b/hapi-osgi-base/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-sourcegen/pom.xml
+++ b/hapi-sourcegen/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-superstructures/pom.xml
+++ b/hapi-structures-superstructures/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
@@ -231,7 +231,7 @@
 						<configuration>
 							<targetDirectory>${basedir}/target/generated-sources/superstructuregen</targetDirectory>
 							<targetStructureName>ADT_AXX</targetStructureName>
-							<version>2.5.1</version>
+							<version>2.5.2</version>
 							<structures>
 								<structure>ADT_A[0-9]{2}</structure>
 							</structures>

--- a/hapi-structures-v21/pom.xml
+++ b/hapi-structures-v21/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v22/pom.xml
+++ b/hapi-structures-v22/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v23/pom.xml
+++ b/hapi-structures-v23/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v231-alternatenames/pom.xml
+++ b/hapi-structures-v231-alternatenames/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v231/pom.xml
+++ b/hapi-structures-v231/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v24/pom.xml
+++ b/hapi-structures-v24/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v25/pom.xml
+++ b/hapi-structures-v25/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v251/pom.xml
+++ b/hapi-structures-v251/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
@@ -24,7 +24,7 @@
 
 	<properties>
 		<gen.skip>false</gen.skip>
-		<gen.version>2.5.1</gen.version>
+		<gen.version>2.5.2</gen.version>
 		<gen.version.short>v251</gen.version.short>
 	</properties>
 

--- a/hapi-structures-v26/pom.xml
+++ b/hapi-structures-v26/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v27/pom.xml
+++ b/hapi-structures-v27/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v28/pom.xml
+++ b/hapi-structures-v28/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-structures-v281/pom.xml
+++ b/hapi-structures-v281/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/hapi-test/pom.xml
+++ b/hapi-test/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-test/src/test/java/ca/uhn/hl7v2/model/AbstractMessageTest.java
+++ b/hapi-test/src/test/java/ca/uhn/hl7v2/model/AbstractMessageTest.java
@@ -1,34 +1,27 @@
 package ca.uhn.hl7v2.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-import java.io.IOException;
-
+import ca.uhn.hl7v2.*;
+import ca.uhn.hl7v2.model.v22.message.ADT_A01;
+import ca.uhn.hl7v2.model.v22.segment.MSA;
 import ca.uhn.hl7v2.model.v25.group.RAS_O17_ADMINISTRATION;
 import ca.uhn.hl7v2.model.v25.group.RAS_O17_ORDER;
 import ca.uhn.hl7v2.model.v25.message.RAS_O17;
-import ca.uhn.hl7v2.model.v25.segment.MSH;
-import ca.uhn.hl7v2.model.v25.segment.ORC;
-import ca.uhn.hl7v2.model.v25.segment.PID;
-import ca.uhn.hl7v2.model.v25.segment.PV1;
-import ca.uhn.hl7v2.model.v25.segment.RXA;
-import org.junit.Assert;
-import org.junit.Test;
-
-import ca.uhn.hl7v2.AcknowledgmentCode;
-import ca.uhn.hl7v2.DefaultHapiContext;
-import ca.uhn.hl7v2.HL7Exception;
-import ca.uhn.hl7v2.HapiContext;
-import ca.uhn.hl7v2.Version;
-import ca.uhn.hl7v2.model.v22.message.ADT_A01;
-import ca.uhn.hl7v2.model.v22.segment.MSA;
+import ca.uhn.hl7v2.model.v25.segment.*;
 import ca.uhn.hl7v2.parser.CanonicalModelClassFactory;
 import ca.uhn.hl7v2.parser.ModelClassFactory;
 import ca.uhn.hl7v2.parser.Parser;
 import ca.uhn.hl7v2.parser.PipeParser;
 import ca.uhn.hl7v2.util.Terser;
 import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * JUnit test cases for AbstractMessage
@@ -36,6 +29,7 @@ import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
  * @author bryan
  */
 public class AbstractMessageTest {
+	private static final Logger ourLog = LoggerFactory.getLogger(AbstractMessageTest.class);
 
 	@Test
 	public void testGetVersion() {
@@ -203,9 +197,10 @@ public class AbstractMessageTest {
 	}
 
     @Test
-    public void testCopy_bothOriginalAndClonedContentsAreIdentical() throws HL7Exception {
+    public void testCopy_bothOriginalAndClonedContentsAreIdentical_sourceBuilder() throws HL7Exception {
         Message orginalMessage = createMessage();
         String originalMessageContents = orginalMessage.encode();
+
         Message copiedMessage = ((AbstractMessage)orginalMessage).copy();
         String copiedMessageContents = copiedMessage.encode();
 
@@ -213,6 +208,30 @@ public class AbstractMessageTest {
         assertEquals(originalMessageContents, copiedMessageContents);
         assertEquals(orginalMessage.printStructure(), copiedMessage.printStructure());
     }
+
+	@Test
+	public void testCopy_bothOriginalAndClonedContentsAreIdentical_sourceString() throws HL7Exception {
+		String message = "MSH|^~\\&|||||||RAS^O17^RAS_O17|00001||2.5\r" +
+				"PID|||7000135^^^http://acme.org/mrns^MR~01238638267^^^http://acme.org/secondaryIds^SB||Smith^John^Q^Jr^^^L\r" +
+				"PV1||I|Acme Hospital\\F\\3rd Floor Room 124\r" +
+				"ABC|Some ABC value\r" +
+				"ORC|NW|0001\\F\\http://acme.org/medorders\r" +
+				"RXA||1|20171209071055-0100||0001\\F\\Tylenol\\F\\http://acme.org/meds|10|mg^milligrams^http://unitsofmeasure.org||^Tylenol note 1~^Tylenol note 2\r" +
+				"RXA||2|20171209071055-0200||0002\\F\\Advil\\F\\http://acme.org/meds|20|mg^milligrams^http://unitsofmeasure.org||^Advil note\r" +
+				"ZZZ|Some ZZZ value 1\r" +
+				"ZXC|Some ZXC value 1\r" +
+				"ZXC|Some ZXC value 2";
+
+		Message orginalMessage = new PipeParser().parse(message);
+		String originalMessageContents = orginalMessage.encode();
+
+		Message copiedMessage = ((AbstractMessage)orginalMessage).copy();
+		String copiedMessageContents = copiedMessage.encode();
+
+		assertEquals(orginalMessage.getClass(), copiedMessage.getClass());
+		assertEquals(originalMessageContents, copiedMessageContents);
+		assertEquals(orginalMessage.printStructure(), copiedMessage.printStructure());
+	}
 
     @Test
     public void testCopy_originalAndClonedAreNotTheSameObject() throws HL7Exception {

--- a/hapi-testmindeps/pom.xml
+++ b/hapi-testmindeps/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-testnodeps/pom.xml
+++ b/hapi-testnodeps/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/hapi-testpanel/pom.xml
+++ b/hapi-testpanel/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>hapi</artifactId>
 		<groupId>ca.uhn.hapi</groupId>
-		<version>2.5.1</version>
+		<version>2.5.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>ca.uhn.hapi</groupId>
 	<artifactId>hapi</artifactId>
 	<packaging>pom</packaging>
-	<version>2.5.1</version>
+	<version>2.5.2</version>
 	<name>HAPI - The Open Source Java HL7 Parser and API</name>
 	<url>http://hl7api.sourceforge.net/</url>
 	<description>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,12 @@
 		<title>HAPI</title>
 	</properties>
 	<body>
+		<release version="2.5.2" date="2024-05-16">
+			<action type="fix" dev="Ken Stevens">
+				AbstractMessage.copy() changed Z segments within the message. This has been corrected
+				so the copy() method now returns an identical copy of the original message.
+			</action>
+		</release>
 		<release version="2.5.1" date="2023-11-01">
 			<action type="fix" dev="Emre Dincturk">
 				SimpleServer now waits for its server socket to be closed when stopAndWait is called.

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -86,6 +86,13 @@
 
 		</section>
 
+		<section name="HAPI HL7v2 2.5.2 Released - May 15, 2024">
+			<p>
+				AbstractMessage.copy() changed Z segments within the message. This has been corrected
+				so the copy() method now returns an identical copy of the original message.
+			</p>
+		</section>
+
 		<section name="HAPI HL7v2 2.4.1 and 2.5.1 Released - Nov 1, 2023">
 			<p>
 				A last minute bug found in HAPI FHIR 2.4 and 2.5 was discovered and fixed, so


### PR DESCRIPTION
				AbstractMessage.copy() changed Z segments within the message. This has been corrected
				so the copy() method now returns an identical copy of the original message.